### PR TITLE
Feat/card draw animation

### DIFF
--- a/src/components/FilppableCard.tsx
+++ b/src/components/FilppableCard.tsx
@@ -8,20 +8,22 @@ type CardType = {
   image: string;
   title: string;
   rarity: string;
-  acquiredAt: Date;
+  acquiredAt: Date; // timestamp of when the card was acquired
 };
 
+// Props for the FlippableCard component
 type FlippableCardProps = {
   card: CardType;
-  flipped: boolean;
-  locked: boolean;
-  onFlip: () => void;
+  flipped: boolean; // whether the card is face-up
+  locked: boolean; // whether the card can be flipped again
+  onFlip: () => void; // callback when a flip is attempted
 };
 
 const FlippableCard: React.FC<FlippableCardProps> = ({ card, flipped, locked, onFlip }) => {
+  // Set up flip animation using react-spring
   const springProps = useSpring({
     transform: flipped ? 'rotateY(180deg)' : 'rotateY(0deg)',
-    config: { duration: 600 },
+    config: { duration: 600 }, // control animation speed
   });
 
   return (

--- a/src/components/FilppableCard.tsx
+++ b/src/components/FilppableCard.tsx
@@ -14,30 +14,27 @@ type CardType = {
 type FlippableCardProps = {
   card: CardType;
   flipped: boolean;
+  locked: boolean;
   onFlip: () => void;
 };
 
-const FlippableCard: React.FC<FlippableCardProps> = ({ card, flipped, onFlip }) => {
+const FlippableCard: React.FC<FlippableCardProps> = ({ card, flipped, locked, onFlip }) => {
   const springProps = useSpring({
-    opacity: 1,
     transform: flipped ? 'rotateY(180deg)' : 'rotateY(0deg)',
-    from: { opacity: 0, transform: 'rotateY(0deg)' },
-    config: { duration: 1000 },
+    config: { duration: 600 },
   });
 
   return (
     <animated.div
-      className="flippable-card"
+      className={`flippable-card ${locked ? 'locked' : ''}`}
       style={springProps}
-      onClick={onFlip}
+      onClick={() => {
+        if (!locked) onFlip(); // only allow flip if not locked
+      }}
     >
       {flipped ? (
         <div className="card-front">
-          <Card
-            image={card.image}
-            title={card.title}
-            rarity={card.rarity}
-          />
+          <Card image={card.image} title={card.title} rarity={card.rarity} />
         </div>
       ) : (
         <div className="card-back">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -17,27 +17,31 @@ type HomeProps = {
 const Home: React.FC<HomeProps> = ({ addToInventory }) => {
   const [currentCards, setCurrentCards] = useState<CardType[]>([]);
   const [flippedStates, setFlippedStates] = useState<boolean[]>([]);
+  const [lockedStates, setLockedStates] = useState<boolean[]>([]);
   const [isLoading, setIsLoading] = useState(false);
 
   const handleWishes = (numOfWishes: number) => {
     setIsLoading(true);
-    setTimeout(() => { // Simulate async operation
-      // Generate the specified number of random cards and add timestamps
+    setTimeout(() => {
       const newCards = Array.from({ length: numOfWishes }, () => {
         const card = getRandomCard();
         return { ...card, acquiredAt: new Date() };
       });
-      setCurrentCards(newCards); // Set the newly generated cards
-      setFlippedStates(new Array(numOfWishes).fill(false)); // Reset all cards to the back side
-      addToInventory(newCards); // Add the new cards with timestamps to the inventory
+
+      setCurrentCards(newCards);
+      setFlippedStates(new Array(numOfWishes).fill(false));
+      setLockedStates(new Array(numOfWishes).fill(false));
+      addToInventory(newCards);
       setIsLoading(false);
-      console.log(`${numOfWishes} wish cards:`, newCards); // Debugging log
     }, 100);
   };
 
   const handleFlip = (index: number) => {
-    setFlippedStates((prevFlippedStates) =>
-      prevFlippedStates.map((flipped, i) => (i === index ? !flipped : flipped))
+    setFlippedStates((prev) =>
+      prev.map((flipped, i) => (i === index ? true : flipped)) // force front side only
+    );
+    setLockedStates((prev) =>
+      prev.map((locked, i) => (i === index ? true : locked)) // lock the card
     );
   };
 
@@ -58,6 +62,7 @@ const Home: React.FC<HomeProps> = ({ addToInventory }) => {
             key={index}
             card={card}
             flipped={flippedStates[index]}
+            locked={lockedStates[index]}
             onFlip={() => handleFlip(index)}
           />
         ))}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -7,39 +7,52 @@ type CardType = {
   image: string;
   title: string;
   rarity: string;
-  acquiredAt: Date;
+  acquiredAt: Date; // timestamp of when the card was acquired
 };
 
 type HomeProps = {
-  addToInventory: (cards: CardType[]) => void;
+  addToInventory: (cards: CardType[]) => void; // callback to add cards to user's inventory
 };
 
 const Home: React.FC<HomeProps> = ({ addToInventory }) => {
+  // Stores the cards drawn in the current wish
   const [currentCards, setCurrentCards] = useState<CardType[]>([]);
+  // Tracks which cards are flipped (true = front side showing)
   const [flippedStates, setFlippedStates] = useState<boolean[]>([]);
+  // Tracks which cards are locked (true = cannot flip anymore/locked state)
   const [lockedStates, setLockedStates] = useState<boolean[]>([]);
+  // Tracks whether wishes are being processed
   const [isLoading, setIsLoading] = useState(false);
 
+  // Handles generating wishes (1 or 10)
   const handleWishes = (numOfWishes: number) => {
     setIsLoading(true);
     setTimeout(() => {
+      // Generate random cards and timestamp them
       const newCards = Array.from({ length: numOfWishes }, () => {
         const card = getRandomCard();
         return { ...card, acquiredAt: new Date() };
       });
 
+      // Store new cards and reset flip/lock states
       setCurrentCards(newCards);
       setFlippedStates(new Array(numOfWishes).fill(false));
       setLockedStates(new Array(numOfWishes).fill(false));
+
+      // Add generated cards to the user's permanent inventory
       addToInventory(newCards);
       setIsLoading(false);
-    }, 100);
+    }, 100); // simulate async delay
   };
 
+  // Handles flipping a card at a specific index
   const handleFlip = (index: number) => {
+    // Force card at `index` to flip to front
     setFlippedStates((prev) =>
       prev.map((flipped, i) => (i === index ? true : flipped)) // force front side only
     );
+
+    // Lock the card at `index` to prevent further flipping
     setLockedStates((prev) =>
       prev.map((locked, i) => (i === index ? true : locked)) // lock the card
     );


### PR DESCRIPTION
This PR enhances the Wish Simulator with the following improvements:

1. **Card Locking Functionality**
   - Once a card is flipped to reveal its front, it is locked and cannot be flipped back.
   - Lock state resets when a new wish draw occurs.
   - Ensures consistent user experience and prevents accidental re-flips.

2. **Inline Explanations**
   - Added detailed inline comments in Home.tsx explaining state management:
     - currentCards
     - flippedStates
     - lockedStates
     - isLoading
   - Added inline comments in FlippableCard.tsx explaining:
     - react-spring flip animation
     - callback usage (onFlip)
     - locking mechanism
   - Improves readability and helps developers understand the card flip and locking logic.

3. **Minor Enhancements**
   - Flip animation duration set to 600ms for smooth visual feedback.
   - Conditional click handling based on locked state.

This PR maintains existing functionality while improving usability and code clarity.

Fixes #1 